### PR TITLE
Removing weighting to put on bottom

### DIFF
--- a/carnival.ts
+++ b/carnival.ts
@@ -16,7 +16,7 @@ namespace SpriteKind {
 /**
 * An extension full of carnival goodness
 */
-//% weight=100 color=#b70082 icon="\uf3ff"
+//% color=#b70082 icon="\uf3ff"
 //% groups='["Ball", "Timer", "Countdown", "Game", "Scene"]'
 namespace carnival {
 


### PR DESCRIPTION
Hopefully this will now end up at the bottom with the other extensions.  Do I need to update the tags in pxt.json, too?